### PR TITLE
Fix:AllThe ReportedIssueAboutCustomStatuses

### DIFF
--- a/src/mutations/updateOrderFulfillmentGroup.js
+++ b/src/mutations/updateOrderFulfillmentGroup.js
@@ -10,6 +10,10 @@ const inputSchema = new SimpleSchema({
     type: String,
     optional: true
   },
+  courier_Name: {
+    type: String,
+    optional: true
+  },
   orderFulfillmentGroupId: String,
   orderId: String,
   status: {
@@ -31,6 +35,7 @@ export default async function updateOrderFulfillmentGroup(context, input) {
   const {
     tracking,
     trackingUrl,
+    courier_Name,
     orderFulfillmentGroupId,
     orderId,
     status
@@ -38,7 +43,7 @@ export default async function updateOrderFulfillmentGroup(context, input) {
 
   const { appEvents, collections, userId } = context;
   const { Orders } = collections;
-  console.log("status", status.split("\\ coreOrderWorkflow/created"));
+  // console.log("status", status.split("\\ coreOrderWorkflow/created"));
   // First verify that this order actually exists
   const order = await Orders.findOne({ _id: orderId });
   if (!order) throw new ReactionError("not-found", "Order not found");
@@ -63,6 +68,7 @@ export default async function updateOrderFulfillmentGroup(context, input) {
 
   if (tracking) modifier.$set["shipping.$[group].tracking"] = tracking;
   if (trackingUrl) modifier.$set["shipping.$[group].trackingUrl"] = trackingUrl;
+  if (courier_Name) modifier.$set["shipping.$[group].courier_Name"] = courier_Name;
 
   if (status && orderFulfillmentGroup.workflow.status !== status) {
     modifier.$set["shipping.$[group].workflow.status"] = status;

--- a/src/mutations/updateOrderItem.js
+++ b/src/mutations/updateOrderItem.js
@@ -13,9 +13,15 @@ const inputSchema = new SimpleSchema({
 
   itemId: String,
   orderId: String,
-  status: String
+  status: String,
+  reason: {
+    type: String,
+    optional: true
+  }
 
 });
+
+const statusArray = ["Cancelled", "Out_Of_Stock", "Quality_Issue", "Returned_To_Seller", "Delivered", "Payment_Released", "Restocked", "Refunded"];
 
 /**
  * @method updateOrderItem
@@ -45,6 +51,9 @@ export default async function updateOrderItem(context, input) {
   const { accountId, appEvents, collections, userId } = context;
   const { Orders } = collections;
 
+  if (status === 'Returned_To_Seller' && !reason) {
+    throw new ReactionError("required", "Reason is required when the status is 'Returned_To_Seller'");
+  }
   // First verify that this order actually exists
   const order = await Orders.findOne({ _id: orderId });
   if (!order) throw new ReactionError("not-found", "Order not found");
@@ -67,6 +76,7 @@ export default async function updateOrderItem(context, input) {
   let foundItem = false;
   const updatedGroups = order.shipping.map((group) => {
     let itemToAdd;
+    let groupStatusUpdated = false;
     const updatedItems = group.items.map((item) => {
       if (item._id !== itemId) return item;
       foundItem = true;
@@ -96,7 +106,7 @@ export default async function updateOrderItem(context, input) {
 
       const updatedItem = {
         ...item,
-        // cancelReason: reason,
+        cancelReason: reason,
         // quantity: cancelQuantity
       };
 
@@ -114,9 +124,16 @@ export default async function updateOrderItem(context, input) {
       // We set the status and the update reason if one was provided.
       // This will also decrement the quantity to match the quantity that is being
       // canceled, which will be offset by pushing `itemToAdd` into the array later.
+      if (statusArray.includes(status)) {
+        groupStatusUpdated = true;
+      }
       return updatedItem;
     });
 
+    if (groupStatusUpdated) {
+      group.workflow.status = 'Completed';
+      group.workflow.workflow.push('Completed');
+    }
     // If they canceled fewer than the full quantity of the item, add a new
     // non-canceled item to make up the difference.
     if (itemToAdd) {
@@ -140,7 +157,7 @@ export default async function updateOrderItem(context, input) {
   // If we did not find any matching item ID while looping, something is wrong
   if (!foundItem) throw new ReactionError("not-found", "Order item not found");
 
-  // If all groups are canceled, set the order status to canceled
+  // If all groups are canceled, set the order status to canceled   
   let updatedOrderWorkflow;
   let fullOrderWasCanceled = false;
   const allGroupsAreUpdated = updatedGroups.every((group) => group.workflow.status === status);
@@ -158,6 +175,15 @@ export default async function updateOrderItem(context, input) {
       updatedAt: new Date()
     }
   };
+  const anyItemHasSpecifiedStatus = updatedGroups.some(group =>
+    group.items.some(item =>
+      statusArray.includes(item.workflow.status)
+    )
+  );
+
+  if (anyItemHasSpecifiedStatus) {
+    modifier.$set["workflow.status"] = "Completed";
+  }
 
   if (updatedOrderWorkflow) {
     modifier.$set.workflow = updatedOrderWorkflow;

--- a/src/resolvers/Mutation/updateOrderFulfillmentGroup.js
+++ b/src/resolvers/Mutation/updateOrderFulfillmentGroup.js
@@ -23,7 +23,8 @@ export default async function updateOrderFulfillmentGroup(parentResult, { input 
     orderFulfillmentGroupId,
     status,
     tracking,
-    trackingUrl
+    trackingUrl,
+    courier_Name
   } = input;
 
   const { order } = await context.mutations.updateOrderFulfillmentGroup(context, {
@@ -31,7 +32,8 @@ export default async function updateOrderFulfillmentGroup(parentResult, { input 
     orderFulfillmentGroupId: decodeOrderFulfillmentGroupOpaqueId(orderFulfillmentGroupId),
     status,
     tracking,
-    trackingUrl
+    trackingUrl,
+    courier_Name
   });
 
   return {

--- a/src/resolvers/Mutation/updateOrderItem.js
+++ b/src/resolvers/Mutation/updateOrderItem.js
@@ -20,12 +20,14 @@ export default async function updateOrderItem(parentResult, { input }, context) 
     itemId,
     status,
     orderId,
+    reason = null
   } = input;
 
   const { order } = await context.mutations.updateOrderItem(context, {
     itemId: decodeOrderItemOpaqueId(itemId),
     orderId: decodeOrderOpaqueId(orderId),
-    status
+    status,
+    reason
   });
 
   return {

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -918,6 +918,7 @@ enum subOrderStatus {
   Dispatched_On_Postex
   Dispatched_On_Penta
   Booked_On_Penta
+  Booked_on_PostEx
   Delivered
   Payment_Released
   Restocked
@@ -1053,6 +1054,8 @@ input UpdateOrderFulfillmentGroupInput {
 
   "Set this as the current order fulfillment group shipment tracking reference"
   tracking: String
+
+  courier_Name: String
 
   "Set this as the current order fulfillment group shipment tracking URL"
   trackingUrl: String

--- a/src/simpleSchemas.js
+++ b/src/simpleSchemas.js
@@ -892,6 +892,7 @@ const SelectedFulfillmentOption = new SimpleSchema({
  * @property {Number} totalItemQuantity The total item quantity, sum of all quantities
  * @property {String} tracking Tracking reference ID
  * @property {String} trackingUrl Tracking URL
+ * @property {String} courier_Name Tracking URL
  * @property {String} type Fulfillment type
  * @property {Object} workflow Current status and past statuses for this fulfillment
  */
@@ -927,6 +928,10 @@ export const OrderFulfillmentGroup = new SimpleSchema({
     optional: true,
   },
   trackingUrl: {
+    type: String,
+    optional: true,
+  },
+  courier_Name: {
     type: String,
     optional: true,
   },
@@ -1168,6 +1173,10 @@ export const Order = new SimpleSchema({
   "payments.$": Payment,
   referenceId: {
     type: String,
+  },
+  reason: {
+    type: String,
+    optional: true,
   },
   shipping: [OrderFulfillmentGroup],
   shopId: String,

--- a/src/util/customStatuses.js
+++ b/src/util/customStatuses.js
@@ -30,6 +30,7 @@ export async function onCreateOrder(order, context, createdBy) {
 
     await sendMessage(context, null, buyerMessage, order?.shipping[0]?.address?.phone)
 
+
     createNotification(context, {
         details: null,
         from: createdBy,
@@ -70,7 +71,6 @@ export async function onUpdateOrder(order, context, updatedBy) {
         // Optionally, handle or log the unhandled status appropriately
     }
 
-
 }
 
 export async function onSubOrderUpdated(subOrder, context) {
@@ -91,6 +91,8 @@ export async function onSubOrderUpdated(subOrder, context) {
         await onReturnedToSellerkNotification(subOrder, context, productPurchased)
     } else if (subOrder.workflow && subOrder.workflow.status === "Return_in_Process") {
         await onReturninProcessNotification(subOrder, context, productPurchased)
+    } else if (subOrder.workflow && subOrder.workflow.status === "Dispatched") {
+        await onDispatchedNotification(subOrder, context, productPurchased)
     } else if (subOrder.workflow && subOrder.workflow.status === "Dispatched_On_MP") {
         await onDispatchedOnMPNotification(subOrder, context, productPurchased)
     } else if (subOrder.workflow && subOrder.workflow.status === "Dipatched_On_Leopard") {
@@ -103,6 +105,8 @@ export async function onSubOrderUpdated(subOrder, context) {
         await onDispatchedOnPostexNotification(subOrder, context, productPurchased)
     } else if (subOrder.workflow && subOrder.workflow.status === "Booked_On_Penta") {
         await onBookedOnPentaNotification(subOrder, context, productPurchased)
+    } else if (subOrder.workflow && subOrder.workflow.status === "Booked_on_PostEx") {
+        await onBookedPostEx(subOrder, context, productPurchased)
     } else if (subOrder.workflow && subOrder.workflow.status === "Dispatched_On_Penta") {
         await onDispatchedOnPentaNotification(subOrder, context, productPurchased)
     } else if (subOrder.workflow && subOrder.workflow.status === "Delivered") {
@@ -572,6 +576,42 @@ async function onBookedOnPentaNotification(order, context, productPurchased) {
 
 }
 
+
+async function onBookedPostEx(order, context, productPurchased) {
+
+    const { collections } = context
+    const { Catalog, Products } = collections
+
+    const productId = productPurchased?.ancestors[0]
+    const productLink = await Catalog.findOne({ "product._id": productId })
+    const sellerName = productPurchased.uploadedBy.name
+
+    // console.log("SELLER NAME", sellerName)
+    if (!productLink) throw new ReactionError("not-found", "Product not found");
+
+    const { slug } = productLink.product;
+
+    let sellerMessage =
+        'Subject: Pickup Scheduled for Your Item\n\n' +
+        'Dear ' + sellerName + ',\n\n' +
+        'We would like to inform you that we have scheduled the pickup of your article at https://staging.bizb.store/product/' + slug + ' with our third-party logistics partner. Please ensure that all details previously shared with you are clearly marked on the parcel, and that it is properly packed.\n\n' +
+        'The rider will attempt to pick up the parcel within the next 3 working days. Please ensure you are available to respond promptly to the rider’s calls or messages, which may come from unknown numbers.\n\n' +
+        'When the rider arrives to pick up the parcel, kindly share a picture of the parcel being handed over to them. Without this, we will not be able to accept responsibility for any potential parcel loss.\n\n' +
+        'If the rider visits your address and you are unable to hand over the parcel, you will need to send it to our office using your own means.\n\n' +
+        'In case we receive an update from the courier indicating that your address is not within their service area, you will need to send the parcel to us directly.\n\n' +
+        'Thank you for your cooperation. If you encounter any issues or need further assistance, please don’t hesitate to contact us.\n\n' +
+        'Best regards,\n' +
+        'BizB Team';
+
+
+    // console.log("SLLER MESSAGE in PENTA BOOKED", sellerMessage)
+
+    await sendMessage(context, productPurchased?.uploadedBy?.userId, sellerMessage, null)
+
+
+}
+
+
 async function onDispatchedOnPentaNotification(order, context, productPurchased) {
 
     let buyerMessage =
@@ -720,7 +760,7 @@ async function OnHoldNotification(order, context, productPurchased) {
 
 async function OnRefundedNotification(order, context, productPurchased) {
 
-    let sellerMessage =
+    let buyerMessage =
         'Subject: Refund Process Completed for Your Order\n\n' +
         'Hi ' + order?.shipping[0]?.address?.fullName + ',\n\n' +
         'We hope you\'re doing well! We’re pleased to inform you that the refund for your canceled order ' + order?.referenceId + ' has been successfully processed and credited to your provided account details.\n\n' +
@@ -732,7 +772,7 @@ async function OnRefundedNotification(order, context, productPurchased) {
 
     // console.log("BUYER MESSAGE", sellerMessage);
 
-    await sendMessage(context, productPurchased?.uploadedBy?.userId, sellerMessage, null)
+    await sendMessage(context, null, buyerMessage, order?.shipping[0]?.address?.phone)
 }
 
 async function OnRefundInProcessNotification(order, context, productPurchased) {


### PR DESCRIPTION
Resolves #18 
Impact: **major**
Type: **bugfix**

## Issue

- Incorrect display of custom statuses in certain UI components

- Dispatched status not worked 

- Requesting for adding new status in the custom statuses flow

- Refunded message goes to the seller not going to the buyer 

- Main order status not changed when the child order status should be in there in the provided list 

- Reson not implemented when the status should be return_to_seller

- tracking, tracking_URL, courier_Name not in the custom status flow 

## Solution

- Fix the Dispatched status issue that is not working 

- Add the new request status in the custom status message flow

- Resolve the updating the main order status when the child order status is applied in the provided list
- Add the Reason field in the update order item mutation when the reason filed is required for statues 
- add the tracking number, tracking URL, and courier name if the update fulfillment group mutation when the order is dispatched
-
## Breaking changes
updateOrderItems.js - Add the reason and the update main order status logic in that file 
updateFullFillMentGroup.js - add the tracking number, tracking URL, and courier name in that file 
customStatus.js - Fix Dispatch status and add new status in that file also fix the message that is sent to the seller, not to the buyer 

## Testing
1. Test the custom status and verify it appears correctly.
2. Test newly added status work properly
3. Main order status is updated successfully when the child order available in the list 
4. Verify no other parts of the app are affected by these changes
5. Reason, tracking number, tracking URL, and courier name work properly when needed